### PR TITLE
refactor: remove calls to mhonarc

### DIFF
--- a/backend/mlarchive/bin/call-archives-pipe.py
+++ b/backend/mlarchive/bin/call-archives-pipe.py
@@ -1,5 +1,4 @@
 #!/a/mailarch/current/env/bin/python
-from __future__ import print_function
 
 '''
 The purpose of this script is to allow mailman to use multiple archiving systems.
@@ -23,56 +22,41 @@ import email
 import getpass
 import logging
 import logging.handlers
-import os
 import socket
 import sys
 import traceback
 from subprocess import Popen, PIPE, STDOUT
     
-MHONARC = '/a/ietf/scripts/archive-mail.pl'
-MAILARCH= '/a/mailarch/current/backend/mlarchive/bin/archive-mail.py'
+
+MAILARCH = '/a/mailarch/current/backend/mlarchive/bin/archive-mail.py'
 MAILTO = ['rcross@amsl.com', 'glen@amsl.com']    # send errors to these addrs
+
 
 def handle_error(error):
     """Sends an email with error message to appropriate parties"""
-    fromaddr = '{}@{}'.format(getpass.getuser(),socket.getfqdn())
+    fromaddr = '{}@{}'.format(getpass.getuser(), socket.getfqdn())
     logger = logging.getLogger()
-    handler = logging.handlers.SMTPHandler(mailhost=("localhost",25),
+    handler = logging.handlers.SMTPHandler(mailhost=("localhost", 25),
                                            fromaddr=fromaddr,
                                            toaddrs=MAILTO,
                                            subject="MAILMAN ARCHIVE FAILURE ({})".format(' '.join(sys.argv)))
     logger.addHandler(handler)
     logger.error(error)
     
-old_args = sys.argv[1:]
-new_args = old_args[:]
 
-if len(old_args) > 1:
-    if old_args[1].startswith('--'):                    # convert to single dash
-        old_args[1] = old_args[1][1:]
-    if new_args[1] not in ('--public','--private'):     # dump unsupported options
-        new_args.pop(1)
+new_args = sys.argv[1:]
 
-if hasattr(sys.stdin, 'buffer'):
-    data = sys.stdin.buffer.read()
-else:
-    data = sys.stdin.read()
+if len(new_args) > 1 and new_args[1] not in ('--public', '--private'):     # dump unsupported options
+    new_args.pop(1)
+
+data = sys.stdin.buffer.read()
 
 try:
-    msg = email.message_from_string(data)
+    msg = email.message_from_bytes(data)
     msg_details = 'Message Details:\nFrom:{}\nDate:{}\nMessage ID:{}\n\n'.format(msg.get('from'), msg.get('date'), msg.get('message-id'))
 except Exception:
     msg_details = 'Message Details:\n(not available)'
 
-# for command in ([MHONARC] + old_args, [MAILARCH] + new_args):
-command = [MHONARC] + old_args
-try:
-    p = Popen(command, stdin=PIPE, stdout=PIPE, stderr=STDOUT)
-    (stdoutdata, stderrdata) = p.communicate(input=data)
-    if p.returncode != 0:
-        handle_error('script failed: {}\n\n (exit_code={})\n\n {}\n\n{}'.format(command[0],p.returncode,stdoutdata, msg_details))
-except Exception as error:
-    handle_error(traceback.format_exc())
 
 command = ['/a/mailarch/current/env/bin/python', MAILARCH] + new_args
 cwd = '/a/mailarch/current/backend/mlarchive/bin'
@@ -80,8 +64,8 @@ try:
     p = Popen(command, stdin=PIPE, stdout=PIPE, stderr=STDOUT, cwd=cwd)
     (stdoutdata, stderrdata) = p.communicate(input=data)
     if p.returncode != 0:
-        handle_error('script failed: {}\n\n (exit_code={})\n\n {}\n\n{}'.format(command[0],p.returncode,stdoutdata, msg_details))
-except Exception as error:
+        handle_error('script failed: {}\n\n (exit_code={})\n\n {}\n\n{}'.format(command[0], p.returncode, stdoutdata, msg_details))
+except Exception:
     handle_error(traceback.format_exc())
     
 sys.exit(0)

--- a/backend/mlarchive/bin/call-archives.py
+++ b/backend/mlarchive/bin/call-archives.py
@@ -13,7 +13,6 @@ It first calls the mhonarc system then the new archiver.  If either fail handle_
 is called.
 '''
 
-import email
 import getpass
 import logging
 import logging.handlers
@@ -23,42 +22,22 @@ import sys
 import traceback
 from subprocess import Popen, PIPE, STDOUT
     
-MHONARC = '/a/ietf/scripts/archive-mail.pl'
-MAILARCH= '/a/mailarch/current/backend/mlarchive/bin/archive-mail.py'
+
+MAILARCH = '/a/mailarch/current/backend/mlarchive/bin/archive-mail.py'
 MAILTO = ['rcross@amsl.com', 'glen@amsl.com']    # send errors to these addrs
+
 
 def handle_error(error):
     """Sends an email with error message to appropriate parties"""
-    fromaddr = '{}@{}'.format(getpass.getuser(),socket.getfqdn())
+    fromaddr = '{}@{}'.format(getpass.getuser(), socket.getfqdn())
     logger = logging.getLogger()
-    handler = logging.handlers.SMTPHandler(mailhost=("localhost",25),
+    handler = logging.handlers.SMTPHandler(mailhost=("localhost", 25),
                                            fromaddr=fromaddr,
                                            toaddrs=MAILTO,
                                            subject="MAILMAN ARCHIVE FAILURE ({})".format(' '.join(sys.argv)))
     logger.addHandler(handler)
     logger.error(error)
-    
-'''
-old_args = sys.argv[1:]
-new_args = old_args[:]
 
-if len(old_args) > 1:
-    if old_args[1].startswith('--'):                    # convert to single dash
-        old_args[1] = old_args[1][1:]
-    if new_args[1] not in ('--public','--private'):     # dump unsupported options
-        new_args.pop(1)
-
-if hasattr(sys.stdin, 'buffer'):
-    data = sys.stdin.buffer.read()
-else:
-    data = sys.stdin.read()
-
-try:
-    msg = email.message_from_string(data)
-    msg_details = 'Message Details:\nFrom:{}\nDate:{}\nMessage ID:{}\n\n'.format(msg.get('from'), msg.get('date'), msg.get('message-id'))
-except Exception:
-    msg_details = 'Message Details:\n(not available)'
-'''
 
 path = sys.argv[1]
 with open(path, 'rb') as f:
@@ -68,16 +47,6 @@ listname, access, _ = os.path.basename(path).split('.')
 old_args = [listname, '-' + access]
 new_args = [listname, '--' + access]
 
-'''
-command = [MHONARC] + old_args
-try:
-    p = Popen(command, stdin=PIPE, stdout=PIPE, stderr=STDOUT)
-    (stdoutdata, stderrdata) = p.communicate(input=data)
-    if p.returncode != 0:
-        handle_error('script failed: {}\n\n (exit_code={})\n\n {}\n\n{}'.format(command[0],p.returncode,stdoutdata, path))
-except Exception as error:
-    handle_error(traceback.format_exc())
-'''
 
 command = ['/a/mailarch/current/env/bin/python', MAILARCH] + new_args
 cwd = '/a/mailarch/current/backend/mlarchive/bin'
@@ -85,8 +54,8 @@ try:
     p = Popen(command, stdin=PIPE, stdout=PIPE, stderr=STDOUT, cwd=cwd)
     (stdoutdata, stderrdata) = p.communicate(input=data)
     if p.returncode != 0:
-        handle_error('script failed: {}\n\n (exit_code={})\n\n {}\n\n{}'.format(command[0],p.returncode,stdoutdata, path))
-except Exception as error:
+        handle_error('script failed: {}\n\n (exit_code={})\n\n {}\n\n{}'.format(command[0], p.returncode, stdoutdata, path))
+except Exception:
     handle_error(traceback.format_exc())
     
 sys.exit(0)


### PR DESCRIPTION
We no longer build MHonArc archives. Remove calls to MHonArc from the import scripts.