### PR TITLE
fix: change postfix import to use public as default

### DIFF
--- a/backend/mlarchive/bin/call-archives-pipe.sh
+++ b/backend/mlarchive/bin/call-archives-pipe.sh
@@ -13,7 +13,7 @@
 # ietfarch-ietf-archive:          '|/a/mailarch/current/backend/mlarchive/bin/call-archives-pipe.sh ietf'
 
 # save message
-FILE=`/usr/bin/mktemp -u --tmpdir=/a/mailarch/data/incoming $1.private.XXXXXXXX`
+FILE=`/usr/bin/mktemp -u --tmpdir=/a/mailarch/data/incoming $1.public.XXXXXXXX`
 cat > $FILE
 
 # archive message


### PR DESCRIPTION
As of 08-10-22 all externally hosted lists, processed through postfix, are public lists. This should be the default list access.