### PR TITLE
feat: add list name to browse view. Fixes #3618

### DIFF
--- a/backend/mlarchive/archive/views.py
+++ b/backend/mlarchive/archive/views.py
@@ -464,6 +464,7 @@ class CustomBrowseView(CustomSearchView):
         # settings
         extra['query_string'] = query_string
         extra['browse_list'] = self.list_name
+        extra['browse_list_placeholder'] = 'Search {}'.format(self.list_name)
         extra['queryset_offset'] = '0'
         extra['count'] = get_count(self.search)
 

--- a/backend/mlarchive/static/mlarchive/css/styles.css
+++ b/backend/mlarchive/static/mlarchive/css/styles.css
@@ -375,6 +375,11 @@ ul.export-buttons li {
   margin-bottom: 18px;
 }
 
+.browse-list-name {
+  font-size: 1.5em;
+  color: #f2a341;
+}
+
 a.selected {
   color: #22527b;
   text-decoration: underline;

--- a/backend/mlarchive/templates/archive/search.html
+++ b/backend/mlarchive/templates/archive/search.html
@@ -106,7 +106,11 @@
                         
                         <form name="search-form" id="id_search_form" class="ms-3 my-auto flex-grow-1" method="get">
                             <div class="input-group input-group-sm w-100">
-                                {% render_field form.q class="form-control" type="search" %}
+                                {% if browse_list_placeholder %}
+                                    {% render_field form.q class="form-control" type="search" placeholder=browse_list_placeholder %}
+                                {% else %}
+                                    {% render_field form.q class="form-control" type="search" %}
+                                {% endif %}
                                 <div class="input-group-append">
                                     <button class="btn btn-secondary" type="submit">
                                         <span class="fa fa-search" aria-hidden="true"></span>

--- a/backend/mlarchive/templates/archive/search.html
+++ b/backend/mlarchive/templates/archive/search.html
@@ -1,15 +1,17 @@
 {% extends 'base.html' %}
 {% load static humanize archive_extras widget_tweaks %}
 
-
 {% block title %}{% if browse_list %}{{ browse_list }}{% else %}{{ block.super }} Search Results{% endif %}{% endblock %}
-
 
 {% block content %}
 
     <div id="msg-container">
         <div id="sidebar">
             <div id="search-filters">
+                {% if browse_list %}
+                    <p class="text-center">Viewing List:<br><span class="browse-list-name"><b>{{ browse_list }}</b></span></p>
+                    <hr>
+                {% endif %}
                 <h5 class="mt-4">FILTER BY TIME</h5>
                 <ul class="filter-options" tabindex="-1">
                   <li class="filter-item"><a class="{% selected request 'qdr' '' %}" href="{% query_string '' 'qdr' %}">Anytime</a></li>

--- a/frontend/scss/styles.scss
+++ b/frontend/scss/styles.scss
@@ -407,6 +407,11 @@ ul.export-buttons li {
     margin-bottom: 18px;
 }
 
+.browse-list-name {
+    font-size: 1.5em;
+    color: rgb(242, 163, 65);
+}
+
 a.selected {
     color: $link-hover-color;
     text-decoration: $link-hover-decoration;


### PR DESCRIPTION
This PR adds the list name to the left pane (filter pane) when browsing a list. 

To test, browse a list by typing the list name in to the search field or by selecting from the browse list at /arch/browse/. The list name will appear on the left.

<img width="1342" alt="Screenshot 2023-06-07 at 10 07 49 AM" src="https://github.com/ietf-tools/mailarch/assets/19938627/2715582b-390d-4212-990e-fbc850316336">
