### PR TITLE
ci: fix mysqlclient requirements version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ gunicorn==20.1.0
 html5lib
 jedi==0.17.2              # 0.18 has bug with ipython
 lxml>=3.3.5
-mysqlclient
+mysqlclient==2.1.1
 mock>=2.0.0
 mozilla-django-oidc==2.0.0
 passlib


### PR DESCRIPTION
The latest version of mysqlclient, 2.2.0, has additional environment variable / compiler requirements. Lock in 2.1.1 for now, as we will soon be moving to Postgres.